### PR TITLE
chore(helper): replace Stringy with StringHelper

### DIFF
--- a/src/helpers/TemplateHelper.php
+++ b/src/helpers/TemplateHelper.php
@@ -6,7 +6,6 @@ use craft\helpers\StringHelper;
 
 class TemplateHelper
 {
-
     /**
      * Maximum bytes to read from template files when extracting descriptions
      */
@@ -14,7 +13,6 @@ class TemplateHelper
 
     public static function friendlyTemplateName(string $name): string
     {
-
         $name = preg_replace('/\.(twig|html)$/i', '', $name);
 
         $name = str_replace('_', ' ', $name);


### PR DESCRIPTION
Removes the deprecated Stringy dependency and updates string handling to use Craft’s native StringHelper.

Fixes a fatal error in Craft ^5.9+ caused by the removal of Stringy from craftcms/cms:

> Class "Stringy\Stringy" not found